### PR TITLE
fix: override @xmldom/xmldom version to workaround broken install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3256,14 +3256,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.7.tgz",
-      "integrity": "sha512-syvR8iIJjpTZ/stv7l89UAViwGFh6lbheeOaqSxkYx9YNmIVvPTRH+CT/fpykFtUx5N+8eSMDRvggF9J8GEPzQ==",
-      "engines": {
-        "node": ">=14.6"
-      }
-    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -3608,6 +3600,15 @@
         "source-map-support": "^0.x",
         "teen_process": "^1.15.0",
         "xpath": "^0.x"
+      }
+    },
+    "node_modules/appium-chromedriver/node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/appium-support": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,9 @@
     "wavesurfer.js": "^6.4.0",
     "webdriverio": "^6.12.1"
   },
+  "overrides": {
+    "@xmldom/xmldom": "0.8.10"
+  },
   "publishConfig": {
     "@akashic:registry": "https://registry.npmjs.org/",
     "access": "public"


### PR DESCRIPTION
掲題どおり。

1. engine-files-reftest が使う `appium@1` の依存系に `appium-chromedriver@4.28.0` が存在する
2. `appium-chromedriver@4.28.0` は `@xmldom/xmldom@^0.x` に[依存しており][chromedriver-dep]、現状 0.9.7 が入る
3. その `@xmldom/xmldom` は 0.9.0-beta.9 で破壊的変更があり、 `parseFromString()` の [第二引数が省略できなくなった][xmldom-breaking]
4. `appium-chromedriver@4.28.0` はこれに追従しておらず、 `parseFromString()` を [第二引数なしで呼ぶ][chromedriver-bug]

このため、今まっさらで engine-files-reftest を `npm i` すると確実に `parseFromString()` でエラーになります。

これは appium@1 系最後のバージョンで発生していて、抜本的には v2 系に移行する必要がありそうです。が、 [破壊的変更が多数あり][appium-migration] 方法は自明ではありません。仕方がないので問題が起きない最後のバージョンである `@xmldom/xmldom@0.8.10` に差し替えて凌ぎます。

[xmldom-breaking]: https://github.com/xmldom/xmldom/commit/fbe1887b8d756c6b5bc419596240fec5c61c817a
[chromedriver-dep]: https://github.com/akashic-games/engine-files-reftest/compare/workaround-broken-install?expand=1#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519R3590
[chromedriver-bug]: https://github.com/appium/appium-chromedriver/blob/v4.28.0/lib/storage-client.js#L210
[appium-migration]: https://appium.io/docs/ja/2.1/guides/migrating-1-to-2/
