### PR TITLE
fix selector of canvas on sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased changes
+
+* akashic sandbox 環境で、passiveモードのv3コンテンツが動作しなくなる不具合の修正
+
 ## 3.3.27
 
 * Android モードで DOM 要素の表示を待機するように

--- a/src/scenarioRunner/staticHost/AkashicSandbox.ts
+++ b/src/scenarioRunner/staticHost/AkashicSandbox.ts
@@ -11,7 +11,9 @@ import type { StaticHost, StaticHostParameterObject, StaticHostProcess } from ".
 
 export class AkashicSandboxProcess implements StaticHostProcess {
 	readonly url: string;
-	readonly canvasSelector: string = ".input-handler > canvas";
+	// v3 では input-handler がない。しかしそれとは別に、serve ベースの sandbox は (デフォルトでは) canvas は一つしかないので、そこから辿る。ただしこれは暫定対応
+	// readonly canvasSelector: string = ".input-handler > canvas";
+	readonly canvasSelector: string = "#container > div > canvas";
 	protected _process: ChildProcess;
 
 	constructor(process: ChildProcess, url: string) {


### PR DESCRIPTION
### 概要
- 以下の条件でreftestを実行した場合、reftestが必ずエラーになる
  - v3系のコンテンツ
  - akashic-sandbox環境
  - passiveモード(自動化ツールで直接ゲームを操作するモード)
- その原因は[pdi-browserのv2.4.4](https://github.com/akashic-games/pdi-browser/releases/tag/v2.4.4)(enginev3系に対応するバージョン)でcanvasタグの親divタグからクラス名input-handlerを削除する対応が行われたため
  - 修正前はこのinput-handlerのすぐ下にあるcanvasタグに対して自動ツール(puppeteer)で操作を行なっていたため