### PR TITLE
take screenshot before throwing error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # CHANGELOG
 
-## Unreleased changes
+## 3.3.29
 
 * akashic serve 環境で、passive モードのコンテンツのスクリーンショット画像の撮影領域がずれている問題の修正
+* reftest実行エラー時にスクリーンショットを撮るように
+  * `--error-screenshot-dir-path` オプションでエラー時のスクリーンショット画像を保存するディレクトリを指定できるように
 
 ## 3.3.28
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/engine-files-reftest",
-  "version": "3.3.28",
+  "version": "3.3.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/engine-files-reftest",
-      "version": "3.3.28",
+      "version": "3.3.29",
       "license": "MIT",
       "dependencies": {
         "@akashic/amflow-util": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/engine-files-reftest",
-  "version": "3.3.28",
+  "version": "3.3.29",
   "description": "akashicコンテンツの自動動作確認を行うリポジトリ",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/RunnerUnit.ts
+++ b/src/RunnerUnit.ts
@@ -49,7 +49,7 @@ export class RunnerUnit {
 			entry.executionMode,
 			entry.playTimes
 		);
-		if (entry.enableAudio && this.audioExtractor && ret.status !== "timeout") {
+		if (entry.enableAudio && this.audioExtractor && ret.status !== "timeout" && ret.status !== "error") {
 			const additional = await this.audioExtractor.run(
 				path.resolve(contentDirPath),
 				path.resolve(entry.scenario.path),

--- a/src/RunnerUnit.ts
+++ b/src/RunnerUnit.ts
@@ -21,11 +21,18 @@ export class RunnerUnit {
 	protected scenarioRunner: ScenarioRunner;
 	protected preprocessor: Preprocessor | null;
 	protected audioExtractor: AudioExtractor | null;
+	private readonly testType: TestType;
 
-	constructor(scenarioRunner: ScenarioRunner, preprocessor: Preprocessor | null, audioExtractor: AudioExtractor | null) {
+	constructor(
+		scenarioRunner: ScenarioRunner,
+		preprocessor: Preprocessor | null,
+		audioExtractor: AudioExtractor | null,
+		testType: TestType
+	) {
 		this.scenarioRunner = scenarioRunner;
 		this.preprocessor = preprocessor;
 		this.audioExtractor = audioExtractor;
+		this.testType = testType;
 	}
 
 	async run(entry: NormalizedReftestEntry): Promise<ReftestOutput> {
@@ -56,6 +63,10 @@ export class RunnerUnit {
 				entry.executionMode
 			);
 			ret.screenshots.push(additional);
+		} else if (ret.status === "timeout" || ret.status === "error") {
+			// どのtestTypeで失敗したか分かるようなファイル名にする
+			// TODO: ファイル名を後から変更すべきではない。そもそもfiliNameはScreenshotが持つのではなく、ファイル書き出し時に初めて決まるべき
+			ret.screenshot.fileName = `${this.testType}_${ret.screenshot.fileName}`;
 		}
 		// 一時的に用意したcontentDirPathは以降不要になるのでここで削除する
 		// TODO: tmpファイルを削除するオプションを用意して、そのオプションが指定された時のみ削除するように
@@ -151,5 +162,5 @@ async function getRunnerUnit(param: GetRunnerUnitParameterObject): Promise<Runne
 		default:
 			throw new Error("Please specify --test-type <type>. <type> is serve, export-zip, export-html, android, or all.");
 	}
-	return new RunnerUnit(scenarioRunner, preprocessor, audioExtractor);
+	return new RunnerUnit(scenarioRunner, preprocessor, audioExtractor, param.testType);
 }

--- a/src/__tests__/RunnerUnitSpec.ts
+++ b/src/__tests__/RunnerUnitSpec.ts
@@ -112,7 +112,7 @@ describe("RunnerUnit", () => {
 			};
 		});
 		test("passiveモードでPreprocessor無しの場合、指定されたスクリプトが差し込まれたディレクトリに対してScenarioRunnerが実行される", async () => {
-			const runnerUnit = new RunnerUnit(scenarioRunner, null, null, "serve");
+			const runnerUnit = new RunnerUnit(scenarioRunner, null, null);
 			const result = await runnerUnit.run(reftestEntry);
 			// run() の戻り型 `ReftestOutput` の `ReftestOutputTimeout` は screenshots プロパティが存在しないため参照するとエラーとなる。status 判定してビルドを通している。
 			if (result.status !== "succeeded") throw new Error("failed because status is different");
@@ -128,7 +128,7 @@ describe("RunnerUnit", () => {
 			);
 		});
 		test("replayモードでPreprocessor無しの場合、指定されたスクリプトとhelperモジュールが差し込まれたディレクトリに対してScenarioRunnerが実行される", async () => {
-			const runnerUnit = new RunnerUnit(scenarioRunner, null, null, "serve");
+			const runnerUnit = new RunnerUnit(scenarioRunner, null, null);
 			reftestEntry.executionMode = "replay";
 			const result = await runnerUnit.run(reftestEntry);
 			if (result.status !== "succeeded") throw new Error("failed because status is different");
@@ -144,7 +144,7 @@ describe("RunnerUnit", () => {
 			);
 		});
 		test("passiveモードでPreprocessorありの場合、Preprocessorが実行され、指定されたスクリプトが差し込まれたディレクトリに対してScenarioRunnerが実行される", async () => {
-			const runnerUnit = new RunnerUnit(scenarioRunner, preprocessor, null, "export-zip");
+			const runnerUnit = new RunnerUnit(scenarioRunner, preprocessor, null);
 			const result = await runnerUnit.run(reftestEntry);
 			if (result.status !== "succeeded") throw new Error("failed because status is different");
 			expect(injectScripts).toHaveBeenCalledTimes(1);
@@ -160,7 +160,7 @@ describe("RunnerUnit", () => {
 			expect(preprocessor.run).toBeCalled();
 		});
 		test("replayモードでPreprocessorありの場合、Preprocessorが実行され、指定されたスクリプトとhelperモジュールが差し込まれたディレクトリに対してScenarioRunnerが実行される", async () => {
-			const runnerUnit = new RunnerUnit(scenarioRunner, preprocessor, null, "export-zip");
+			const runnerUnit = new RunnerUnit(scenarioRunner, preprocessor, null);
 			reftestEntry.executionMode = "replay";
 			const result = await runnerUnit.run(reftestEntry);
 			if (result.status !== "succeeded") throw new Error("failed because status is different");
@@ -178,7 +178,7 @@ describe("RunnerUnit", () => {
 		});
 		// AudioExtractorの実行は一時的に止めているためテストもスキップ
 		test("AudioExtractorありの場合、ScenarioRunnerと同様のシグニチャでAudioExtractorが実行される", async () => {
-			const runnerUnit = new RunnerUnit(scenarioRunner, null, audioExtractor, "serve");
+			const runnerUnit = new RunnerUnit(scenarioRunner, null, audioExtractor);
 			const result = await runnerUnit.run(reftestEntry);
 			if (result.status !== "succeeded") throw new Error("failed because status is different");
 			expect(injectScripts).toHaveBeenCalledTimes(1);

--- a/src/__tests__/RunnerUnitSpec.ts
+++ b/src/__tests__/RunnerUnitSpec.ts
@@ -112,7 +112,7 @@ describe("RunnerUnit", () => {
 			};
 		});
 		test("passiveモードでPreprocessor無しの場合、指定されたスクリプトが差し込まれたディレクトリに対してScenarioRunnerが実行される", async () => {
-			const runnerUnit = new RunnerUnit(scenarioRunner, null, null);
+			const runnerUnit = new RunnerUnit(scenarioRunner, null, null, "serve");
 			const result = await runnerUnit.run(reftestEntry);
 			// run() の戻り型 `ReftestOutput` の `ReftestOutputTimeout` は screenshots プロパティが存在しないため参照するとエラーとなる。status 判定してビルドを通している。
 			if (result.status !== "succeeded") throw new Error("failed because status is different");
@@ -128,7 +128,7 @@ describe("RunnerUnit", () => {
 			);
 		});
 		test("replayモードでPreprocessor無しの場合、指定されたスクリプトとhelperモジュールが差し込まれたディレクトリに対してScenarioRunnerが実行される", async () => {
-			const runnerUnit = new RunnerUnit(scenarioRunner, null, null);
+			const runnerUnit = new RunnerUnit(scenarioRunner, null, null, "serve");
 			reftestEntry.executionMode = "replay";
 			const result = await runnerUnit.run(reftestEntry);
 			if (result.status !== "succeeded") throw new Error("failed because status is different");
@@ -144,7 +144,7 @@ describe("RunnerUnit", () => {
 			);
 		});
 		test("passiveモードでPreprocessorありの場合、Preprocessorが実行され、指定されたスクリプトが差し込まれたディレクトリに対してScenarioRunnerが実行される", async () => {
-			const runnerUnit = new RunnerUnit(scenarioRunner, preprocessor, null);
+			const runnerUnit = new RunnerUnit(scenarioRunner, preprocessor, null, "export-zip");
 			const result = await runnerUnit.run(reftestEntry);
 			if (result.status !== "succeeded") throw new Error("failed because status is different");
 			expect(injectScripts).toHaveBeenCalledTimes(1);
@@ -160,7 +160,7 @@ describe("RunnerUnit", () => {
 			expect(preprocessor.run).toBeCalled();
 		});
 		test("replayモードでPreprocessorありの場合、Preprocessorが実行され、指定されたスクリプトとhelperモジュールが差し込まれたディレクトリに対してScenarioRunnerが実行される", async () => {
-			const runnerUnit = new RunnerUnit(scenarioRunner, preprocessor, null);
+			const runnerUnit = new RunnerUnit(scenarioRunner, preprocessor, null, "export-zip");
 			reftestEntry.executionMode = "replay";
 			const result = await runnerUnit.run(reftestEntry);
 			if (result.status !== "succeeded") throw new Error("failed because status is different");
@@ -178,7 +178,7 @@ describe("RunnerUnit", () => {
 		});
 		// AudioExtractorの実行は一時的に止めているためテストもスキップ
 		test("AudioExtractorありの場合、ScenarioRunnerと同様のシグニチャでAudioExtractorが実行される", async () => {
-			const runnerUnit = new RunnerUnit(scenarioRunner, null, audioExtractor);
+			const runnerUnit = new RunnerUnit(scenarioRunner, null, audioExtractor, "serve");
 			const result = await runnerUnit.run(reftestEntry);
 			if (result.status !== "succeeded") throw new Error("failed because status is different");
 			expect(injectScripts).toHaveBeenCalledTimes(1);

--- a/src/__tests__/RunnerUnitSpec.ts
+++ b/src/__tests__/RunnerUnitSpec.ts
@@ -225,6 +225,7 @@ describe("withRunnerUnit", () => {
 			android: null,
 			outputHtml: null,
 			timeoutErrorDirPath: null,
+			errorScreenshotDirPath: null,
 			useNpmCache: false,
 			npmCacheDir: path.resolve(".", ".npmcache")
 		};

--- a/src/__tests__/configure/ReftestConfigureSpec.ts
+++ b/src/__tests__/configure/ReftestConfigureSpec.ts
@@ -23,6 +23,7 @@ describe("ReftestConfigure", () => {
 				android: null,
 				outputHtml: null,
 				timeoutErrorDirPath: null,
+				errorScreenshotDirPath: null,
 				useNpmCache: false,
 				npmCacheDir: path.resolve(".", "__bincache")
 			});
@@ -45,6 +46,7 @@ describe("ReftestConfigure", () => {
 				threshold: 0,
 				outputHtml: null,
 				timeoutErrorDirPath: null,
+				errorScreenshotDirPath: null,
 				useNpmCache: false,
 				npmCacheDir: path.resolve(path.resolve(__dirname, "../fixture"), "__bincache")
 			});
@@ -82,6 +84,7 @@ describe("ReftestConfigure", () => {
 				threshold: 0.03,
 				outputHtml: null,
 				timeoutErrorDirPath: null,
+				errorScreenshotDirPath: null,
 				useNpmCache: false,
 				npmCacheDir: path.resolve(path.resolve(__dirname, "../fixture"), "__bincache"),
 				android: {

--- a/src/configure/ReftestConfigure.ts
+++ b/src/configure/ReftestConfigure.ts
@@ -33,6 +33,7 @@ export interface ReftestCommandOption {
 	androidAppActivity?: string;
 	outputHtml?: string;
 	timeoutErrorDirPath?: string;
+	errorScreenshotDirPath?: string;
 	useNpmCache?: boolean;
 	npmCacheDirPath?: string;
 }
@@ -62,6 +63,7 @@ export interface ReftestConfigure {
 	android: AndroidConfigure | null;
 	outputHtml: string | null;
 	timeoutErrorDirPath: string | null;
+	errorScreenshotDirPath: string | null;
 	useNpmCache: boolean | false;
 	npmCacheDir: string | null;
 }
@@ -83,6 +85,7 @@ export interface NormalizedReftestConfigure extends ReftestConfigure {
 	android: AndroidConfigure | null;
 	outputHtml: string | null;
 	timeoutErrorDirPath: string | null;
+	errorScreenshotDirPath: string | null;
 	useNpmCache: boolean;
 	npmCacheDir: string;
 }
@@ -124,6 +127,7 @@ export function createReftestConfigure(option: ReftestCommandOption): Normalized
 			android: null,
 			outputHtml: null,
 			timeoutErrorDirPath: null,
+			errorScreenshotDirPath: null,
 			useNpmCache: false,
 			npmCacheDir: null,
 		};
@@ -145,6 +149,7 @@ export function createReftestConfigure(option: ReftestCommandOption): Normalized
 	configure.threshold = option.threshold ?? (configure.threshold ?? null);
 	configure.outputHtml = option.outputHtml ?? resolvePath(dirPath, configure.outputHtml);
 	configure.timeoutErrorDirPath = option.timeoutErrorDirPath ?? resolvePath(dirPath, configure.timeoutErrorDirPath);
+	configure.errorScreenshotDirPath = option.errorScreenshotDirPath ?? resolvePath(dirPath, configure.errorScreenshotDirPath);
 	configure.useNpmCache = option.useNpmCache ?? (configure.useNpmCache ?? false);
 	configure.npmCacheDir = option.npmCacheDirPath ?? null;
 	if (option.androidApkPath || option.androidPlaylogClientPath) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { normalizeReftestEntry } from "./configure/ReftestEntry";
 import { renderHtmlReport } from "./outputResult/renderHtmlReport";
 import { renderHtmlReportIndex } from "./outputResult/renderHtmlReportIndex";
 import { withRunnerUnit } from "./RunnerUnit";
+import type { ReftestOutputWithScreenshots } from "./scenarioRunner/ScenarioRunner";
 import type { ReftestMode } from "./types/ReftestMode";
 import type { ReftestResult } from "./types/ReftestResult";
 import type { Screenshot } from "./types/Screenshot";
@@ -21,7 +22,6 @@ import type { FileDiff } from "./util/FileDiff";
 import { initializeNpmDir } from "./util/initializeNpmDir";
 import { mkdirpSync } from "./util/mkdirpSync";
 import { resolveRootDirPath } from "./util/resolveRootDirPath";
-import { ReftestOutputWithScreenshots } from "./scenarioRunner/ScenarioRunner";
 
 const ver = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "package.json"), "utf8")).version;
 
@@ -126,7 +126,7 @@ void (async () => {
 							if (mode === "update-expected" || mode === "update-expected-only-diff") {
 								throw new Error(`Timeout Error on "${reftestEntry.selfPath}"`);
 							}
-						break;
+							break;
 					}
 					if (mode === "update-expected" || mode === "update-expected-only-diff") {
 						if (fs.existsSync(expectedDir)) {

--- a/src/scenarioRunner/ScenarioRunner.ts
+++ b/src/scenarioRunner/ScenarioRunner.ts
@@ -20,6 +20,7 @@ interface ReftestOutputError {
 }
 
 export type ReftestOutput = ReftestOutputSucceeded | ReftestOutputSkipped | ReftestOutputTimeout | ReftestOutputError;
+export type ReftestOutputWithScreenshots = ReftestOutputSucceeded | ReftestOutputSkipped;
 
 export interface ScenarioRunner {
 	/**

--- a/src/scenarioRunner/ScenarioRunner.ts
+++ b/src/scenarioRunner/ScenarioRunner.ts
@@ -11,11 +11,11 @@ interface ReftestOutputSkipped {
 }
 interface ReftestOutputTimeout {
 	status: "timeout";
-	timeoutImage: Screenshot;
+	screenshot: Screenshot;
 }
 interface ReftestOutputError {
 	status: "error";
-	errorScreenshot: Screenshot;
+	screenshot: Screenshot;
 	error: any;
 }
 

--- a/src/scenarioRunner/ScenarioRunner.ts
+++ b/src/scenarioRunner/ScenarioRunner.ts
@@ -13,8 +13,13 @@ interface ReftestOutputTimeout {
 	status: "timeout";
 	timeoutImage: Screenshot;
 }
+interface ReftestOutputError {
+	status: "error";
+	errorScreenshot: Screenshot;
+	error: any;
+}
 
-export type ReftestOutput = ReftestOutputSucceeded | ReftestOutputSkipped | ReftestOutputTimeout;
+export type ReftestOutput = ReftestOutputSucceeded | ReftestOutputSkipped | ReftestOutputTimeout | ReftestOutputError;
 
 export interface ScenarioRunner {
 	/**

--- a/src/scenarioRunner/android/createAndroidScenarioRunner.ts
+++ b/src/scenarioRunner/android/createAndroidScenarioRunner.ts
@@ -78,13 +78,14 @@ export async function createAndroidScenarioRunner(param: CreateAndroidScenarioRu
 					appActivity: param.appActivity ?? undefined
 				}
 			});
+			let playCount = 0;
 			try {
 				if (mode === "replay") {
 					const modeButton = await client.$("id:active");
 					await assertDisplayed(modeButton, "mode button(id:active) is not displayed");
 					await modeButton.click();
 				}
-				for (let playCount = 0; playCount < playTimes; playCount++) {
+				for (; playCount < playTimes; playCount++) {
 					const contentWaiter = createWaiter();
 					contentOutputReceiver.onScreenshot.add(s => {
 						screenshots.push({
@@ -126,11 +127,12 @@ export async function createAndroidScenarioRunner(param: CreateAndroidScenarioRu
 				}
 			} catch (e) {
 				// エラーが発生した場合は、コンテンツのスクリーンショットを取得しておく
-				const errorScreenshot: Screenshot = {
-					fileName: `error_try${screenshots.length}_${extractDirname(scenarioPath)}.png`,
+				// TODO: この辺りのエラーハンドリングは他のScenarioRunnerとほぼ同じコードになっているので、「シナリオを実行してエラー時にスクリーンショットを撮る」一連の流れを共通化すべき
+				const screenshot: Screenshot = {
+					fileName: `error_try${playCount}_${extractDirname(scenarioPath)}.png`,
 					base64: await client.takeScreenshot()
 				};
-				return { status: "error", errorScreenshot, error: e };
+				return { status: "error", screenshot, error: e };
 			} finally {
 				await client.deleteSession();
 				await serveProcess.stop();

--- a/src/scenarioRunner/android/createAndroidScenarioRunner.ts
+++ b/src/scenarioRunner/android/createAndroidScenarioRunner.ts
@@ -19,6 +19,7 @@ const CONTENT_LIMIT_TIME = 300000; // コンテンツ実行時間の上限
 const ANDROID_ELEMENT_TIMEOUT = 10000; // Androidエミュレータの要素取得タイムアウト
 
 interface CreateAndroidScenarioRunnerParameterObject {
+	type: "android";
 	serveBinSrc: TargetBinarySource;
 	apkPath: string;
 	playlogClientPath: string;
@@ -129,7 +130,7 @@ export async function createAndroidScenarioRunner(param: CreateAndroidScenarioRu
 				// エラーが発生した場合は、コンテンツのスクリーンショットを取得しておく
 				// TODO: この辺りのエラーハンドリングは他のScenarioRunnerとほぼ同じコードになっているので、「シナリオを実行してエラー時にスクリーンショットを撮る」一連の流れを共通化すべき
 				const screenshot: Screenshot = {
-					fileName: `error_try${playCount}_${extractDirname(scenarioPath)}.png`,
+					fileName: `${param.type}_error_try${playCount}_${extractDirname(scenarioPath)}.png`,
 					base64: await client.takeScreenshot()
 				};
 				return { status: "error", screenshot, error: e };

--- a/src/scenarioRunner/serve/createServeScenarioRunner.ts
+++ b/src/scenarioRunner/serve/createServeScenarioRunner.ts
@@ -92,19 +92,20 @@ export async function createServeScenarioRunner(binSrc: TargetBinarySource): Pro
 					}
 				}
 			} catch (e) {
+				// TODO: この辺りのエラーハンドリングは他のScenarioRunnerとほぼ同じコードになっているので、「シナリオを実行してエラー時にスクリーンショットを撮る」一連の流れを共通化すべき
 				if (e instanceof TimeoutError) {
-					const timeoutImage: Screenshot = {
+					const screenshot: Screenshot = {
 						fileName: `timeout_try${playCount}_${extractDirname(scenarioPath)}.png`,
 						base64: await page.screenshot({ encoding: "base64" })
 					};
-					return { status: "timeout", timeoutImage };
+					return { status: "timeout", screenshot };
 				} else {
 					if (page && !page.isClosed()) {
-						const errorScreenshot: Screenshot = {
+						const screenshot: Screenshot = {
 							fileName: `error_try${playCount}_${extractDirname(scenarioPath)}.png`,
 							base64: await page.screenshot({ encoding: "base64" })
 						};
-						return { status: "error", errorScreenshot, error: e };
+						return { status: "error", screenshot, error: e };
 					}
 					throw e;
 				}

--- a/src/scenarioRunner/serve/createServeScenarioRunner.ts
+++ b/src/scenarioRunner/serve/createServeScenarioRunner.ts
@@ -15,8 +15,13 @@ import { createAkashicServe } from "./AkashicServe";
 // コンテンツ実行時間の上限。テスト時に実行時間がこの長さを超える場合、確実に失敗することに注意が必要
 const CONTENT_LIMIT_MAX_TIME = 300000;
 
-export async function createServeScenarioRunner(binSrc: TargetBinarySource): Promise<ScenarioRunner> {
-	const serveBin = await createAkashicServe(binSrc);
+interface CreateServeScenarioRunnerParameterObject {
+	type: "serve" | "export-zip";
+	binSrc: TargetBinarySource;
+}
+
+export async function createServeScenarioRunner(param: CreateServeScenarioRunnerParameterObject): Promise<ScenarioRunner> {
+	const serveBin = await createAkashicServe(param.binSrc);
 	return {
 		run: async (
 			contentDirPath: string,
@@ -95,14 +100,14 @@ export async function createServeScenarioRunner(binSrc: TargetBinarySource): Pro
 				// TODO: この辺りのエラーハンドリングは他のScenarioRunnerとほぼ同じコードになっているので、「シナリオを実行してエラー時にスクリーンショットを撮る」一連の流れを共通化すべき
 				if (e instanceof TimeoutError) {
 					const screenshot: Screenshot = {
-						fileName: `timeout_try${playCount}_${extractDirname(scenarioPath)}.png`,
+						fileName: `${param.type}_timeout_try${playCount}_${extractDirname(scenarioPath)}.png`,
 						base64: await page.screenshot({ encoding: "base64" })
 					};
 					return { status: "timeout", screenshot };
 				} else {
 					if (page && !page.isClosed()) {
 						const screenshot: Screenshot = {
-							fileName: `error_try${playCount}_${extractDirname(scenarioPath)}.png`,
+							fileName: `${param.type}_error_try${playCount}_${extractDirname(scenarioPath)}.png`,
 							base64: await page.screenshot({ encoding: "base64" })
 						};
 						return { status: "error", screenshot, error: e };

--- a/src/scenarioRunner/serve/createServeScenarioRunner.ts
+++ b/src/scenarioRunner/serve/createServeScenarioRunner.ts
@@ -99,6 +99,13 @@ export async function createServeScenarioRunner(binSrc: TargetBinarySource): Pro
 					};
 					return { status: "timeout", timeoutImage };
 				} else {
+					if (page && !page.isClosed()) {
+						const errorScreenshot: Screenshot = {
+							fileName: `error_try${playCount}_${extractDirname(scenarioPath)}.png`,
+							base64: await page.screenshot({ encoding: "base64" })
+						};
+						return { status: "error", errorScreenshot, error: e };
+					}
 					throw e;
 				}
 			} finally {

--- a/src/scenarioRunner/staticHost/createStaticHostScenarioRunner.ts
+++ b/src/scenarioRunner/staticHost/createStaticHostScenarioRunner.ts
@@ -51,19 +51,20 @@ export async function createStaticHostScenarioRunner(hostBin: StaticHost): Promi
 					await page.close();
 				}
 			} catch (e) {
+				// TODO: この辺りのエラーハンドリングは他のScenarioRunnerとほぼ同じコードになっているので、「シナリオを実行してエラー時にスクリーンショットを撮る」一連の流れを共通化すべき
 				if (e instanceof TimeoutError) {
-					const timeoutImage: Screenshot = {
+					const screenshot: Screenshot = {
 						fileName: `timeout_try${playCount}_${extractDirname(scenarioPath)}.png`,
 						base64: await page!.screenshot({ encoding: "base64" }) // TimeoutError は withTimeLimit() から来るので、page は代入済みのはず
 					};
-					return { status: "timeout", timeoutImage };
+					return { status: "timeout", screenshot };
 				} else {
 					if (page && !page.isClosed()) {
-						const errorScreenshot: Screenshot = {
+						const screenshot: Screenshot = {
 							fileName: `error_try${playCount}_${extractDirname(scenarioPath)}.png`,
 							base64: await page.screenshot({ encoding: "base64" })
 						};
-						return { status: "error", errorScreenshot, error: e };
+						return { status: "error", screenshot, error: e };
 					}
 					throw e;
 				}

--- a/src/scenarioRunner/staticHost/createStaticHostScenarioRunner.ts
+++ b/src/scenarioRunner/staticHost/createStaticHostScenarioRunner.ts
@@ -58,6 +58,13 @@ export async function createStaticHostScenarioRunner(hostBin: StaticHost): Promi
 					};
 					return { status: "timeout", timeoutImage };
 				} else {
+					if (page && !page.isClosed()) {
+						const errorScreenshot: Screenshot = {
+							fileName: `error_try${playCount}_${extractDirname(scenarioPath)}.png`,
+							base64: await page.screenshot({ encoding: "base64" })
+						};
+						return { status: "error", errorScreenshot, error: e };
+					}
 					throw e;
 				}
 			} finally {

--- a/src/scenarioRunner/staticHost/createStaticHostScenarioRunner.ts
+++ b/src/scenarioRunner/staticHost/createStaticHostScenarioRunner.ts
@@ -9,8 +9,13 @@ import type { StaticHost } from "./StaticHost";
 
 const CONTENT_LIMIT_TIME = 300000; // コンテンツ実行時間の上限
 
+interface CreateStaticHostScenarioRunnerParameterObject {
+	type: "sandbox" | "export-html";
+	hostBin: StaticHost;
+}
+
 // このScenarioRunnerはコンテンツをリアルタイムモードでしか実行できないので、modeは必ずpassiveとなる
-export async function createStaticHostScenarioRunner(hostBin: StaticHost): Promise<ScenarioRunner> {
+export async function createStaticHostScenarioRunner(param: CreateStaticHostScenarioRunnerParameterObject): Promise<ScenarioRunner> {
 	return {
 		run: async (
 			contentDirPath: string,
@@ -22,7 +27,7 @@ export async function createStaticHostScenarioRunner(hostBin: StaticHost): Promi
 				return { status: "skipped-unsupported", screenshots: [] };
 
 			const screenshots: Screenshot[] = [];
-			const serveProcess = await hostBin.start({ contentDirPath, hostname: "localhost" });
+			const serveProcess = await param.hostBin.start({ contentDirPath, hostname: "localhost" });
 			const browser = await puppeteer.launch({
 				headless: true,
 				executablePath: process.env.CHROME_BIN || undefined,
@@ -54,14 +59,14 @@ export async function createStaticHostScenarioRunner(hostBin: StaticHost): Promi
 				// TODO: この辺りのエラーハンドリングは他のScenarioRunnerとほぼ同じコードになっているので、「シナリオを実行してエラー時にスクリーンショットを撮る」一連の流れを共通化すべき
 				if (e instanceof TimeoutError) {
 					const screenshot: Screenshot = {
-						fileName: `timeout_try${playCount}_${extractDirname(scenarioPath)}.png`,
+						fileName: `${param.type}_timeout_try${playCount}_${extractDirname(scenarioPath)}.png`,
 						base64: await page!.screenshot({ encoding: "base64" }) // TimeoutError は withTimeLimit() から来るので、page は代入済みのはず
 					};
 					return { status: "timeout", screenshot };
 				} else {
 					if (page && !page.isClosed()) {
 						const screenshot: Screenshot = {
-							fileName: `error_try${playCount}_${extractDirname(scenarioPath)}.png`,
+							fileName: `${param.type}_error_try${playCount}_${extractDirname(scenarioPath)}.png`,
 							base64: await page.screenshot({ encoding: "base64" })
 						};
 						return { status: "error", screenshot, error: e };
@@ -79,7 +84,7 @@ export async function createStaticHostScenarioRunner(hostBin: StaticHost): Promi
 			// do nothing
 		},
 		getVersionInfo: (): string => {
-			return hostBin.getVersionInfo();
+			return param.hostBin.getVersionInfo();
 		}
 	};
 }

--- a/src/types/Screenshot.ts
+++ b/src/types/Screenshot.ts
@@ -1,3 +1,4 @@
+// TODO: filiNameはScreenshotが持つのではなく、ファイル書き出し時に初めて決まるべき
 export interface Screenshot {
 	fileName: string;
 	base64: string;


### PR DESCRIPTION
### 概要
reftestの実行に失敗しても原因が特定できない場合がある(特にandroid環境)ので、エラー時にスクリーンショットを撮るようにした

### やったこと
- エラー時のスクリーンショット画像を保存するディレクトリを`--error-screenshot-dir-path`で指定できるように
- 正解画像更新時も、タイムアウト時やエラー時のスクリーンショット画像を取得するように