### PR TITLE
fix screenshot area when passive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased changes
+
+* akashic sandbox 環境で、passive モードのコンテンツのスクリーンショット画像の撮影領域がずれている問題の修正
+
 ## 3.3.28
 
 * akashic sandbox 環境で、passiveモードのv3コンテンツが動作しなくなる不具合の修正

--- a/src/scenarioRunner/evaluateScenario.ts
+++ b/src/scenarioRunner/evaluateScenario.ts
@@ -7,9 +7,17 @@ import type { Screenshot } from "../types/Screenshot";
 export async function evaluateScenarioByPuppeteer(
 	page: puppeteer.Page,
 	playlogJsonPath: string,
+	gameJsonPath?: string,
 	takeScreenshotFunc?: (s: Screenshot) => void,
 	selector: string = "canvas"
 ): Promise<void> {
+	if (gameJsonPath) {
+		// game.jsonの動的読み込みのため、require の lint エラーを抑止
+		/* eslint-disable @typescript-eslint/no-require-imports */
+		const gameJson = require(gameJsonPath);
+		// コンテンツ描画領域が他の要素と重ならないようにするために、画面サイズをコンテンツのサイズよりも大きくする
+		await page.setViewport({ width: Math.round(1.1 * gameJson.width), height: Math.round(1.1 * gameJson.height) });
+	}
 	await page.waitForSelector(selector);
 	// canvas 要素が存在する環境で実行する前提なので、! を付与する
 	const canvasHandle = (await page.$(selector))!;

--- a/src/scenarioRunner/serve/createServeScenarioRunner.ts
+++ b/src/scenarioRunner/serve/createServeScenarioRunner.ts
@@ -1,3 +1,4 @@
+import * as path from "path";
 import { calculateFinishedTime } from "@akashic/amflow-util/lib/calculateFinishedTime";
 import * as puppeteer from "puppeteer";
 import type { TargetBinarySource } from "../../targetBinary/TargetBinarySource";
@@ -76,9 +77,14 @@ export async function createServeScenarioRunner(binSrc: TargetBinarySource): Pro
 					await withTimeLimit(Math.min(expectedTime, CONTENT_LIMIT_MAX_TIME), "content did not end in time", () => {
 						return mode === "replay" ?
 							contentWaiter.promise :
-							evaluateScenarioByPuppeteer(page, playlogJsonPath, (s: Screenshot) => {
-								contentOutputReceiver.onScreenshot.fire(s);
-							});
+							evaluateScenarioByPuppeteer(
+								page,
+								playlogJsonPath,
+								path.resolve(contentDirPath, "game.json"),
+								(s: Screenshot) => {
+									contentOutputReceiver.onScreenshot.fire(s);
+								}
+							);
 					});
 					contentOutputReceiver.onScreenshot.removeAll();
 					contentOutputReceiver.onFinish.removeAll();


### PR DESCRIPTION
### 概要
- akashic serve環境でpassiveモードのコンテンツを実行してスクリーンショット画像を撮ると、意図していない領域が撮影されてしまう問題があった。
-  この問題の原因は、puppeteer実行時のウィンドウサイズがコンテンツのサイズより小さかったことだった。
- そのため、passiveモードでコンテンツを実行する時はウィンドウサイズをコンテンツのサイズよりやや大きくするという対応を追加した(replayモードではスクリーンショット画像の撮影はpupeteerではなくコンテンツ自身が行うのでこの問題は発生しない。)

### やったこと
- `evaluateScenarioByPuppeteer()`でgameJsonPathを引数で受け取って、game.jsonからコンテンツサイズを取得して、ウィンドウサイズをコンテンツサイズの1.1倍にするように(serveの場合ピッタリサイズだと上のツールバーと被ってしまうため)。